### PR TITLE
feat: Enforce Node.js version requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "git+https://github.com/narodb/naro.git"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "homepage": "https://github.com/narodb/naro",
   "scripts": {
     "dev:bun": "bun ./src/index.ts",


### PR DESCRIPTION
Specify a minimum Node.js version (>=18.0.0) in the "engines" field. This ensures compatibility and prevents errors when using an unsupported Node.js version.