### PR TITLE
feat: get structured collections

### DIFF
--- a/__test__/unit/base/Naro.test.ts
+++ b/__test__/unit/base/Naro.test.ts
@@ -349,5 +349,17 @@ test("clear, should throw an error if has collection identifier", async () => {
   await expect(async () => await db.clear("users/123")).rejects.toThrowError();
 })
 
+test("getStructuredCollections, should return the structured collections", async () => {
+  const db = new Naro(dbName);
+  await db.add("users", { name: faker.person.fullName(), phone: faker.phone.number() });
+  await db.add("products", { name: faker.commerce.productName(), price: faker.commerce.price() });
+  const collections = db.getStructuredCollections();
+
+  expect(collections).toEqual({
+    users: expect.any(Array),
+    products: expect.any(Array)
+  });
+})
+
 
 

--- a/src/base/Naro.ts
+++ b/src/base/Naro.ts
@@ -426,6 +426,18 @@ export class Naro {
     if (collectionId) throw new Error("Collection ID detected. Use delete method instead.");
     this.core.removeCollection(collectionName);
   }
+
+  /**
+   * Retrieves all collections in the database as a structured object.
+   * Each key in the returned object represents a collection name,
+   * and the value is an array of documents within that collection.
+   *
+   * @return {Record<string, NaroDocument[]>} An object containing all collections
+   * and their respective documents.
+   */
+  getStructuredCollections(): Record<string, NaroDocument[]> {
+    return this.core.getStructuredCollections();
+  }
 }
 
 


### PR DESCRIPTION
`db.getStructuredCollections` Retrieves all collections in the database as a structured object. Each key in the returned object represents a collection name, and the value is an array of documents within that collection.